### PR TITLE
Added matte in use property

### DIFF
--- a/src/layers/layer.ts
+++ b/src/layers/layer.ts
@@ -25,6 +25,7 @@ export abstract class Layer {
   public timeStretch = 1;
   public matteMode?: MatteMode;
   public matteTarget?: number;
+  public matteInUse?: number;
   public isHidden?: boolean;
   public matchName?: string;
   public masks: Mask[] = [];
@@ -115,6 +116,10 @@ export abstract class Layer {
       this.matteMode = json.tt;
     }
 
+    if ('tp' in json) {
+      this.matteInUse = json.tp;
+    }
+
     if ('td' in json) {
       this.matteTarget = json.td;
     }
@@ -155,6 +160,7 @@ export abstract class Layer {
       nm: this.name,
       mn: this.matchName,
       tt: this.matteMode,
+      tp: this.matteInUse,
       td: this.matteTarget,
       cl: this.classNames.length ? this.classNames.join(' ') : undefined,
       ln: this.id,

--- a/src/values/text-document.ts
+++ b/src/values/text-document.ts
@@ -15,6 +15,7 @@ export class TextDocument implements Value {
   public textTracking?: number;
   public strokeColor?: Color;
   public strokeWidth?: number;
+  public baselineShift?: number;
 
   /**
    * Convert the Lottie JSON object to class instance.
@@ -35,6 +36,7 @@ export class TextDocument implements Value {
     document.textCaps = json.ca;
     document.textTracking = json.tr;
     document.strokeWidth = json.sw;
+    document.baselineShift = json.ls;
 
     if ('sc' in json) {
       document.strokeColor = Color.fromJSON(json.sc);
@@ -56,6 +58,7 @@ export class TextDocument implements Value {
       tr: this.textTracking,
       sc: this.strokeColor,
       sw: this.strokeWidth,
+      ls: this.baselineShift,
     };
   }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Matte Parent (tp) was not present at all.
Baseline Shift property of TextDocument was missing.

## What is the new behavior?

- matte parent (tp) available as layer.matteInUse
- Baseline Shift for text Document (ls) available as TextDocument.baselineShift

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
