### PR TITLE
CRR Update

### DIFF
--- a/src/layers/layer.ts
+++ b/src/layers/layer.ts
@@ -25,7 +25,7 @@ export abstract class Layer {
   public timeStretch = 1;
   public matteMode?: MatteMode;
   public matteTarget?: number;
-  public matteInUse?: number;
+  public matteParent?: number;
   public isHidden?: boolean;
   public matchName?: string;
   public masks: Mask[] = [];
@@ -117,7 +117,7 @@ export abstract class Layer {
     }
 
     if ('tp' in json) {
-      this.matteInUse = json.tp;
+      this.matteParent = json.tp;
     }
 
     if ('td' in json) {
@@ -160,7 +160,7 @@ export abstract class Layer {
       nm: this.name,
       mn: this.matchName,
       tt: this.matteMode,
-      tp: this.matteInUse,
+      tp: this.matteParent,
       td: this.matteTarget,
       cl: this.classNames.length ? this.classNames.join(' ') : undefined,
       ln: this.id,


### PR DESCRIPTION
Updated variable from matteInUse to matteParent, according to docs: https://lottiefiles.github.io/lottie-docs/schema/#//layers/visual-layer

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Matte Parent (`tp`) was not present at all.
First was added as `matteInUse`, now replaced to `matteParent`, following docs.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- matte parent (`tp`) available as `layer`.`matteParent`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
